### PR TITLE
 Fix Chrome & Chromedriver installation using Chrome for Testing

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -30,7 +30,7 @@ jobs:
           set_env_var: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
       - run: git clone git@github.com:QuickPay/klarna-payments-backend.git
       - run: gem install bundler -v 2.4.22
       - name: Tests

--- a/index.js
+++ b/index.js
@@ -20,47 +20,24 @@ async function run() {
     const envVar = getBool("set_env_var")
 
     if (chrome) {
-      // Install Chrome
-      cp.execSync('wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb')
-      cp.execSync('sudo apt-get install -y ./google-chrome-stable_current_amd64.deb')
+      cp.execSync('wget -q -O /tmp/chrome-versions.json "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"')
+      const stableChannel = JSON.parse(fs.readFileSync('/tmp/chrome-versions.json', 'utf8')).channels.Stable
+      const downloads = stableChannel.downloads
 
-      try {
-        const chromeVersionOutput = cp.execSync('google-chrome --version').toString()
-        console.log('Chrome version output:', chromeVersionOutput)
+      const chromeUrl = downloads.chrome.find(d => d.platform === 'linux64').url
+      const chromedriverUrl = downloads.chromedriver.find(d => d.platform === 'linux64').url
 
-        const chromeVersionMatch = chromeVersionOutput.match(/\d+\.\d+\.\d+\.\d+/)
-        if (!chromeVersionMatch) {
-          throw new Error('Could not extract Chrome version from: ' + chromeVersionOutput)
-        }
+      console.log(`Downloading Chrome version: ${stableChannel.version}`)
+      cp.execSync(`wget -q -O /tmp/chrome-linux64.zip "${chromeUrl}"`)
+      cp.execSync('unzip -q /tmp/chrome-linux64.zip -d /tmp/chrome-linux64')
+      cp.execSync('sudo mv /tmp/chrome-linux64/chrome-linux64/chrome /usr/local/bin/google-chrome')
+      cp.execSync('sudo chmod +x /usr/local/bin/google-chrome')
 
-        const chromeVersion = chromeVersionMatch[0]
-        console.log('Chrome version:', chromeVersion)
-
-        const chromedriverUrl = `https://storage.googleapis.com/chrome-for-testing-public/${chromeVersion}/linux64/chromedriver-linux64.zip`
-        console.log('Downloading chromedriver from:', chromedriverUrl)
-
-        try {
-          cp.execSync(`wget -q -O chromedriver.zip "${chromedriverUrl}"`)
-        } catch (_e) {
-          const versionPrefix = chromeVersion.split('.').slice(0, 3).join('.')
-          cp.execSync('wget -q -O /tmp/chromedriver-versions.json "https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json"')
-          const builds = JSON.parse(fs.readFileSync('/tmp/chromedriver-versions.json', 'utf8')).builds
-          const fallbackUrl = builds[versionPrefix].downloads.chromedriver.find(d => d.platform === 'linux64').url
-          console.log('Falling back to chromedriver:', fallbackUrl)
-          cp.execSync(`wget -q -O chromedriver.zip "${fallbackUrl}"`)
-        }
-
-        cp.execSync('unzip -q chromedriver.zip')
-        cp.execSync('sudo mv chromedriver-linux64/chromedriver /usr/local/bin/')
-        cp.execSync('sudo chmod +x /usr/local/bin/chromedriver')
-
-        cp.execSync('rm -rf chromedriver.zip chromedriver-linux64 google-chrome-stable_current_amd64.deb')
-
-        console.log('Chromedriver installed successfully')
-      } catch (error) {
-        core.setFailed('Failed to install Chromedriver: ' + error.message)
-        return
-      }
+      console.log(`Downloading Chromedriver version: ${stableChannel.version}`)
+      cp.execSync(`wget -q -O /tmp/chromedriver-linux64.zip "${chromedriverUrl}"`)
+      cp.execSync('unzip -q /tmp/chromedriver-linux64.zip -d /tmp/chromedriver-linux64')
+      cp.execSync('sudo mv /tmp/chromedriver-linux64/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver')
+      cp.execSync('sudo chmod +x /usr/local/bin/chromedriver')
     }
     if (chrome || prodAptDeps || postgres) {
       cp.execSync("DEBIAN_FRONTEND=noninteractive sudo apt-get update")

--- a/index.js
+++ b/index.js
@@ -32,13 +32,57 @@ async function run() {
         if (!chromeVersionMatch) {
           throw new Error('Could not extract Chrome version from: ' + chromeVersionOutput)
         }
-        const chromeVersion = chromeVersionMatch[0]
-        console.log('Chrome version:', chromeVersion)
 
-        const chromedriverUrl = `https://storage.googleapis.com/chrome-for-testing-public/${chromeVersion}/linux64/chromedriver-linux64.zip`
+        const chromeVersion = chromeVersionMatch[0]
+        const versionPrefix = chromeVersion.split('.').slice(0, 3).join('.') // ✅ FIXED
+        console.log('Chrome version:', chromeVersion)
+        console.log('Version prefix:', versionPrefix)
+
+        let chromedriverUrl = `https://storage.googleapis.com/chrome-for-testing-public/${chromeVersion}/linux64/chromedriver-linux64.zip`
         console.log('Downloading chromedriver from:', chromedriverUrl)
 
-        cp.execSync(`wget -q -O chromedriver.zip "${chromedriverUrl}"`)
+        try {
+          // Try exact version first
+          cp.execSync(`wget -q -O chromedriver.zip "${chromedriverUrl}"`)
+        } catch (_exactVersionError) {
+          console.log(`Exact version ${chromeVersion} not found, falling back to matching build ${versionPrefix}...`)
+
+          cp.execSync(
+            'wget -q -O /tmp/chromedriver-versions.json "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"'
+          )
+
+          const versionsData = JSON.parse(fs.readFileSync('/tmp/chromedriver-versions.json', 'utf8'))
+
+
+          const matchingVersions = versionsData.versions.filter(v =>
+            v.version.startsWith(versionPrefix) &&
+            v.downloads.chromedriver &&
+            v.downloads.chromedriver.some(d => d.platform === 'linux64')
+          )
+
+          if (matchingVersions.length === 0) {
+            throw new Error(`No chromedriver found for Chrome build ${versionPrefix}`)
+          }
+
+
+          matchingVersions.sort((a, b) =>
+            a.version.localeCompare(b.version, undefined, { numeric: true })
+          )
+
+          const fallbackVersion = matchingVersions.pop()
+          const fallbackDownload = fallbackVersion.downloads.chromedriver.find(
+            d => d.platform === 'linux64'
+          )
+
+          chromedriverUrl = fallbackDownload.url
+
+          console.log(
+            `Falling back to chromedriver version ${fallbackVersion.version}, downloading from: ${chromedriverUrl}`
+          )
+
+          cp.execSync(`wget -q -O chromedriver.zip "${chromedriverUrl}"`)
+        }
+
         cp.execSync('unzip -q chromedriver.zip')
         cp.execSync('sudo mv chromedriver-linux64/chromedriver /usr/local/bin/')
         cp.execSync('sudo chmod +x /usr/local/bin/chromedriver')

--- a/index.js
+++ b/index.js
@@ -34,53 +34,20 @@ async function run() {
         }
 
         const chromeVersion = chromeVersionMatch[0]
-        const versionPrefix = chromeVersion.split('.').slice(0, 3).join('.') // ✅ FIXED
         console.log('Chrome version:', chromeVersion)
-        console.log('Version prefix:', versionPrefix)
 
-        let chromedriverUrl = `https://storage.googleapis.com/chrome-for-testing-public/${chromeVersion}/linux64/chromedriver-linux64.zip`
+        const chromedriverUrl = `https://storage.googleapis.com/chrome-for-testing-public/${chromeVersion}/linux64/chromedriver-linux64.zip`
         console.log('Downloading chromedriver from:', chromedriverUrl)
 
         try {
-          // Try exact version first
           cp.execSync(`wget -q -O chromedriver.zip "${chromedriverUrl}"`)
-        } catch (_exactVersionError) {
-          console.log(`Exact version ${chromeVersion} not found, falling back to matching build ${versionPrefix}...`)
-
-          cp.execSync(
-            'wget -q -O /tmp/chromedriver-versions.json "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"'
-          )
-
-          const versionsData = JSON.parse(fs.readFileSync('/tmp/chromedriver-versions.json', 'utf8'))
-
-
-          const matchingVersions = versionsData.versions.filter(v =>
-            v.version.startsWith(versionPrefix) &&
-            v.downloads.chromedriver &&
-            v.downloads.chromedriver.some(d => d.platform === 'linux64')
-          )
-
-          if (matchingVersions.length === 0) {
-            throw new Error(`No chromedriver found for Chrome build ${versionPrefix}`)
-          }
-
-
-          matchingVersions.sort((a, b) =>
-            a.version.localeCompare(b.version, undefined, { numeric: true })
-          )
-
-          const fallbackVersion = matchingVersions.pop()
-          const fallbackDownload = fallbackVersion.downloads.chromedriver.find(
-            d => d.platform === 'linux64'
-          )
-
-          chromedriverUrl = fallbackDownload.url
-
-          console.log(
-            `Falling back to chromedriver version ${fallbackVersion.version}, downloading from: ${chromedriverUrl}`
-          )
-
-          cp.execSync(`wget -q -O chromedriver.zip "${chromedriverUrl}"`)
+        } catch (_e) {
+          const versionPrefix = chromeVersion.split('.').slice(0, 3).join('.')
+          cp.execSync('wget -q -O /tmp/chromedriver-versions.json "https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json"')
+          const builds = JSON.parse(fs.readFileSync('/tmp/chromedriver-versions.json', 'utf8')).builds
+          const fallbackUrl = builds[versionPrefix].downloads.chromedriver.find(d => d.platform === 'linux64').url
+          console.log('Falling back to chromedriver:', fallbackUrl)
+          cp.execSync(`wget -q -O chromedriver.zip "${fallbackUrl}"`)
         }
 
         cp.execSync('unzip -q chromedriver.zip')

--- a/integration_test/test/env_var_spec.rb
+++ b/integration_test/test/env_var_spec.rb
@@ -7,6 +7,6 @@ describe "Envorimental Variable loaded" do
     end
 
     it "has correct values" do
-        _(YAML.load(ENV["SETTINGS"])["default"][:service_discovery][:reader]).must_equal "tcp://33.33.33.80:22122"
+        _(YAML.load(ENV["SETTINGS"], aliases: true)["default"][:service_discovery][:reader]).must_equal "tcp://33.33.33.80:22122"
     end
 end


### PR DESCRIPTION
## Problem

Chrome for Testing does not publish a chromedriver binary for every Chrome release. When the installed Chrome version (e.g. `146.0.7680.164`) has no matching chromedriver at the exact URL, the `wget` command fails and the action errors out.
https://github.com/QuickPay/manager/actions/runs/23494135067/job/68371526465

### Solution

Replace the old approach with a single fetch from the [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) API:
